### PR TITLE
add vscode config files + remove automatic run behavior when enabling + update run times + Add config template file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
-.vscode/
 
 # Spyder project settings
 .spyderproject

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "ms-azuretools.vscode-azurefunctions",
+    "ms-python.python"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach to Python Functions",
+      "type": "python",
+      "request": "attach",
+      "port": 9091,
+      "preLaunchTask": "func: host start"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "azureFunctions.deploySubpath": ".",
+    "azureFunctions.scmDoBuildDuringDeployment": true,
+    "azureFunctions.pythonVenv": ".venv",
+    "azureFunctions.projectLanguage": "Python",
+    "azureFunctions.projectRuntime": "~4",
+    "debug.internalConsoleOptions": "neverOpen"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,27 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "func",
+      "label": "func: host start",
+      "command": "host start",
+      "problemMatcher": "$func-python-watch",
+      "isBackground": true,
+      "dependsOn": "pip install (functions)"
+    },
+    {
+      "label": "pip install (functions)",
+      "type": "shell",
+      "osx": {
+        "command": "${config:azureFunctions.pythonVenv}/bin/python -m pip install -r requirements.txt"
+      },
+      "windows": {
+        "command": "${config:azureFunctions.pythonVenv}/Scripts/python -m pip install -r requirements.txt"
+      },
+      "linux": {
+        "command": "${config:azureFunctions.pythonVenv}/bin/python -m pip install -r requirements.txt"
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/StartAdxCluster/function.json
+++ b/StartAdxCluster/function.json
@@ -5,7 +5,8 @@
       "name": "startadxtimer",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 0 6 * * 1-5"
+      "schedule": "0 0 7 * * 1-5",
+      "useMonitor": false
     }
   ]
 }

--- a/StartAks/function.json
+++ b/StartAks/function.json
@@ -5,7 +5,8 @@
       "name": "startakstimer",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 0 6 * * 1-5"
+      "schedule": "0 0 7 * * 1-5",
+      "useMonitor": false
     }
   ]
 }

--- a/StopAdxCluster/function.json
+++ b/StopAdxCluster/function.json
@@ -5,7 +5,8 @@
       "name": "stopadxtimer",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 6 18 * * 1-5"
+      "schedule": "0 0 19 * * 1-5",
+      "useMonitor": false
     }
   ]
 }

--- a/StopAks/function.json
+++ b/StopAks/function.json
@@ -5,7 +5,8 @@
       "name": "stopakstimer",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 6 18 * * 1-5"
+      "schedule": "0 0 19 * * 1-5",
+      "useMonitor": false
     }
   ]
 }

--- a/config-sample.json
+++ b/config-sample.json
@@ -1,0 +1,92 @@
+[
+    {
+      "name": "ADX_CLUSTER_NAME",
+      "value": "xxx",
+      "slotSetting": false
+    },
+    {
+      "name": "ADX_RESOURCE_GROUP",
+      "value": "xxx",
+      "slotSetting": false
+    },
+    {
+      "name": "AKS_CLUSTER_NAME",
+      "value": "xxx",
+      "slotSetting": false
+    },
+    {
+      "name": "AKS_RESOURCE_GROUP",
+      "value": "xxx",
+      "slotSetting": false
+    },
+    {
+      "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+      "value": "Set automatically at deployment",
+      "slotSetting": false
+    },
+    {
+      "name": "AZURE_CLIENT_ID",
+      "value": "xxx",
+      "slotSetting": false
+    },
+    {
+      "name": "AZURE_CLIENT_SECRET",
+      "value": "xxx",
+      "slotSetting": false
+    },
+    {
+      "name": "AZURE_SUBSCRIPTION_ID",
+      "value": "xxx",
+      "slotSetting": false
+    },
+    {
+      "name": "AZURE_TENANT_ID",
+      "value": "xxx",
+      "slotSetting": false
+    },
+    {
+      "name": "AzureWebJobs.ResumePowerBI.Disabled",
+      "value": "true",
+      "slotSetting": false
+    },
+    {
+      "name": "AzureWebJobs.StartStudioVM.Disabled",
+      "value": "true",
+      "slotSetting": false
+    },
+    {
+      "name": "AzureWebJobs.StopBowerBI.Disabled",
+      "value": "true",
+      "slotSetting": false
+    },
+    {
+      "name": "AzureWebJobs.StopStudioVM.Disabled",
+      "value": "true",
+      "slotSetting": false
+    },
+    {
+      "name": "AzureWebJobsStorage",
+      "value": "Set automatically at deployment",
+      "slotSetting": false
+    },
+    {
+      "name": "FUNCTIONS_EXTENSION_VERSION",
+      "value": "~4",
+      "slotSetting": false
+    },
+    {
+      "name": "FUNCTIONS_WORKER_RUNTIME",
+      "value": "python",
+      "slotSetting": false
+    },
+    {
+      "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
+      "value": "Set automatically at deployment",
+      "slotSetting": false
+    },
+    {
+      "name": "WEBSITE_CONTENTSHARE",
+      "value": "Set automatically at deployment",
+      "slotSetting": false
+    }
+  ]


### PR DESCRIPTION
Salut,

Lorsque l'on mettait les fonctions de stop / start en "disabled" afin de laisser une plateforme démarrée, au moment de réactiver les fonctions, celles-ci s'exécutaient automatiquement alors que ça n'était pas l'heure. Ce comportement est désactivé en ajoutant le paramètre "useMonitor=false".

Ce commit modifie aussi les heures de stop / start afin d'avoir une plage de run à Lundi-Vendredi, 8h - 20h GMT+1 (heure d'hiver.

+ Ajout d'un exemple de fichier de configuration de l'Azure Fonction. 

Merci !
JC